### PR TITLE
Install emoji-mart dependency

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -17,6 +17,7 @@
         "@fortawesome/react-fontawesome": "^0.2.0",
         "axios": "^1.4.0",
         "bootstrap": "^5.2.3",
+        "emoji-mart": "^5.5.2",
         "react": "^18.2.0",
         "react-bootstrap": "^2.7.4",
         "react-dom": "^18.2.0",
@@ -1570,8 +1571,7 @@
     "node_modules/emoji-mart": {
       "version": "5.5.2",
       "resolved": "https://registry.npmjs.org/emoji-mart/-/emoji-mart-5.5.2.tgz",
-      "integrity": "sha512-Sqc/nso4cjxhOwWJsp9xkVm8OF5c+mJLZJFoFfzRuKO+yWiN7K8c96xmtughYb0d/fZ8UC6cLIQ/p4BR6Pv3/A==",
-      "peer": true
+      "integrity": "sha512-Sqc/nso4cjxhOwWJsp9xkVm8OF5c+mJLZJFoFfzRuKO+yWiN7K8c96xmtughYb0d/fZ8UC6cLIQ/p4BR6Pv3/A=="
     },
     "node_modules/es-abstract": {
       "version": "1.21.2",

--- a/client/package.json
+++ b/client/package.json
@@ -19,7 +19,7 @@
     "@fortawesome/react-fontawesome": "^0.2.0",
     "axios": "^1.4.0",
     "bootstrap": "^5.2.3",
-
+    "emoji-mart": "^5.5.2",
     "react": "^18.2.0",
     "react-bootstrap": "^2.7.4",
     "react-dom": "^18.2.0",


### PR DESCRIPTION
For some reason, emoji-mart wasn't included in the dependencies list.
I had to install it manually to start it up.